### PR TITLE
Fetch non-annotated git tags in build script

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -31,7 +31,8 @@ sha512sums=('SKIP')
 
 pkgver() {
   cd "${_realname}"
-  git describe --abbrev=8 | tr '-' '_'
+  git fetch --tags
+  git describe --tags --abbrev=8 | tr '-' '_'
 }
 
 build() {


### PR DESCRIPTION
`git describe` doesn't fetch lightweight tags by default. This causes the build script to fall back onto the default branch of the repo if a non-annotated (lightweight) tag is passed to `run.sh`. This PR fixes this.